### PR TITLE
Google Analytics設定を追加

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -3,6 +3,8 @@ languageCode = 'en-us'
 title = 'My New Hugo Site'
 theme = "paper"
 
+googleAnalytics = "G-3EB73WSJ9K"
+
 [[menu.posts]]
 identifier = "posts"
 name = "posts"


### PR DESCRIPTION
HugoはGAサポートがある
https://gohugo.io/templates/internal/
https://helve-blog.com/posts/web-technology/hugo-google-analytics-tag/

`config.toml` の `googleAnalytics` 項目設定により自動的にGAのJSが含まれるようになっているように見える